### PR TITLE
Fixed it innit AKA How I learned to not be dumb and read the docs

### DIFF
--- a/src/main/bot/commands/spotify/queue-song.ts
+++ b/src/main/bot/commands/spotify/queue-song.ts
@@ -66,7 +66,7 @@ export class QueueSong extends BaseCommand {
         const tracks = trackData.body.tracks.items
 
         if (tracks.length === 0) {
-          message.channel.send('I was unable to find any tracks by the name' + songName).catch(logger.error)
+          message.channel.send('I was unable to find any tracks by the name ' + songName).catch(logger.error)
           await this.crossReactMessage(message)
           return
         }

--- a/src/main/common/spotifyHelper.ts
+++ b/src/main/common/spotifyHelper.ts
@@ -76,7 +76,12 @@ export class SpotifyHelper {
 
       connection = new SpotifyConnection(oldConnection.userId, data.body.access_token, data.body.refresh_token, refreshDate)
       this.spotifyApi.setAccessToken(connection.connectionToken)
-      this.spotifyApi.setRefreshToken(connection.refreshToken)
+
+      /*
+        refreshAccessToken only returns a new access token (you'd think this would be obvious right?.......)
+        So we keep the old refresh token, but change the access token with the new one.
+      */
+      this.spotifyApi.setRefreshToken(oldConnection.refreshToken)
       this.cache[connection.userId] = connection
 
       await this.db.updateSpotifyKeyForUser(connection.userId, connection.connectionToken, connection.expires)

--- a/src/main/common/spotifyHelper.ts
+++ b/src/main/common/spotifyHelper.ts
@@ -74,14 +74,14 @@ export class SpotifyHelper {
       let refreshDate: Date = new Date()
       refreshDate.setSeconds(refreshDate.getSeconds() + data.body.expires_in - 10)
 
-      connection = new SpotifyConnection(oldConnection.userId, data.body.access_token, data.body.refresh_token, refreshDate)
-      this.spotifyApi.setAccessToken(connection.connectionToken)
-
       /*
         refreshAccessToken only returns a new access token (you'd think this would be obvious right?.......)
         So we keep the old refresh token, but change the access token with the new one.
       */
-      this.spotifyApi.setRefreshToken(oldConnection.refreshToken)
+      connection = new SpotifyConnection(oldConnection.userId, data.body.access_token, oldConnection.refreshToken, refreshDate)
+      this.spotifyApi.setAccessToken(connection.connectionToken)
+      this.spotifyApi.setRefreshToken(connection.refreshToken)
+
       this.cache[connection.userId] = connection
 
       await this.db.updateSpotifyKeyForUser(connection.userId, connection.connectionToken, connection.expires)


### PR DESCRIPTION
Fixed an issue where a refresh token would be overridden with `undefined` in the Spotify cache after a refresh occured.